### PR TITLE
Revise egm

### DIFF
--- a/scope.qmd
+++ b/scope.qmd
@@ -91,7 +91,7 @@ ggplot(complete_matrix1,
              alpha = 0.6, position = position_jitterdodge(jitter.width = 0.2, 
                                                           dodge.width = 0.5)) +
   scale_y_discrete(limits = rev) +
-  scale_size_continuous(range = c(3, 12),
+  scale_size_continuous(range = c(3, 10),
                         breaks = c(1, 5, 10, 20), 
                         labels = function(x) round(x, 0)) + 
   scale_colour_discrete_qualitative() +


### PR DESCRIPTION
Hi Ayu,

I have attempted to solve the issue with font sizes. This of course means restructuring quite a few things, so it fits better.

My main suggestion is to move the caption out of the figure. Figures in publications (at least in those "high-impact" journals) usually don't have a lot of text within the image, but very long figure captions outside. This has the advantage that the text can easily be changed by anyone, not just the data people.

Please take a look and feel free to merge if this works for you. You could then strive to implement similar changes to the second figure. There, I'd suggest to keep the black border around the panels, so they area easily distinguishable. Other than that, my strategy to optimise the plot is simply to reduce the plotting area `fig.width` and `fig.height`, and then to solve any issues with clipping and general layout that appear).

If you are not familiar with the whole branching and merging on GitHub/git, no worries. I can also send you files if you prefer that.